### PR TITLE
Minor typo in Encapsulation w/ Closures Example

### DIFF
--- a/FE101.md
+++ b/FE101.md
@@ -211,9 +211,9 @@ var myCounter = (() => {
   };
 })(); // self-invocation
 
-console.log(myCounter()); // 0
 console.log(myCounter()); // 1
 console.log(myCounter()); // 2
+console.log(myCounter()); // 3
 ```
 
 ## OOP & Prototypal Inheritance


### PR DESCRIPTION
myCounter function returns 1,2,3,... instead of 0,1,2,...
